### PR TITLE
Make pywikisource use the prp-index-pagelist class

### DIFF
--- a/pywikisource/__init__.py
+++ b/pywikisource/__init__.py
@@ -55,8 +55,8 @@ class WikiSourceApi():
 
         soup = BeautifulSoup(page_soure.text, 'html.parser')
 
-        for div in soup.find_all('div', {"class": 'index-pagelist'}):
-            a = div.find_all('a', {'href': True})
+        for span in soup.find_all('span', {"class": 'prp-index-pagelist'}):
+            a = span.find_all('a', {'href': True})
             for ach in a:
                 # Rid non-exist pages
                 if (ach['class'] == ["new"]) == True:


### PR DESCRIPTION
The index-pagelist class depends on the wiki markup a particular wiki uses to display the pagelist. Instead, use the prp-index-pagelist classes that is provided by default by the ProofreadPage extension.