### PR TITLE
Use max instead of hard coded value

### DIFF
--- a/pywikisource/__init__.py
+++ b/pywikisource/__init__.py
@@ -35,7 +35,7 @@ class WikiSourceApi():
             'format': 'json',
             'prop': 'imageinfo',
             'titles': 'File:{}'.format(index),
-            'iilimit': '50',
+            'iilimit': 'max',
             'iiprop': 'size'
         }
 


### PR DESCRIPTION
Use max instead of hardcoded value. Per MediaWiki API docs