### PR TITLE
Convert the pagelist API to use proofreadpagesinindex API

### DIFF
--- a/pywikisource/__init__.py
+++ b/pywikisource/__init__.py
@@ -63,19 +63,22 @@ class WikiSourceApi():
 
         page_list = []
 
+        params = {
+		    'action': 'query',
+		    'list': 'proofreadpagesinindex',
+		    'prppiititle': 'Index:' + index,
+		    'prppiiprop': 'ids|title',
+            'format': 'json'
+        }
+
         # Get page source
-        page_soure = self.ses.get(('https://{}.wikisource.org/wiki/Index:{}').format(self.lang, index))
-
-        soup = BeautifulSoup(page_soure.text, 'html.parser')
-
-        for span in soup.find_all('span', {"class": 'prp-index-pagelist'}):
-            a = span.find_all('a', {'href': True})
-            for ach in a:
-                # Rid non-exist pages
-                if (ach['class'] == ["new"]) == True:
-                    continue
-                else:
-                    page_list.append(parse.unquote(ach['href'])[6:])
+        data = self.ses.get(self.url_endpoint, params=params).json()
+        try:
+            raw_page_list = list(data['query']['proofreadpagesinindex'])
+            for i in raw_page_list:
+                page_list.append(i['title'])
+        except:
+            pass
 
         return page_list
 


### PR DESCRIPTION
The previous implementation relied on paring the Index page HTML that could cause issues if the pagelist HTML structure changed. Shift over to the proofreadpagesinindex API that should eliminate the need for complicated parsing.