### PR TITLE
Add the Type hinting in Wikisource class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,10 @@ setuptools.setup(
         'requests',
         'bs4',
         'asyncio',
-        'aiohttp'
+        'aiohttp',
+        'typing-extensions'# included typing-extensions for python 3.6, typing is best for strictly python>= 3.9
     ],
+    python_requires='>=3.6',
     setup_requires=['wheel'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Type hinting was introduced in Python 3.5, Wikimedia Toolforge supports the newer versions so it is safe to typed the pywikisource.

In this PR, we are introducing typing to the variables. 

## We utilise typing-extensions library
typing-extensions: Although typing is part of Python’s standard library, typing-extensions is useful for compatibility with certain type hints in older Python versions. You might not need this if you strictly target Python 3.9 or higher, but it's safe to include if your library needs to support older Python versions (>=3.6).

## Python 3.6 versus Python 3.5
Using Python 3.6 or later allows access to key enhancements like f-strings for easier string formatting, improved type hinting with features like variable annotations, and better support for asyncio with async function typing. Python 3.5 lacks these newer language features, making code less concise and harder to maintain. Upgrading to Python 3.6+ also ensures better performance and compatibility with modern libraries.
